### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,4 +1,6 @@
 name: Fly Deploy
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/RemoteRabbit/portfolio-elixir/security/code-scanning/1](https://github.com/RemoteRabbit/portfolio-elixir/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to restrict the `GITHUB_TOKEN` to the minimal required permissions. Since the workflow involves deploying an application and does not appear to require write access to the repository, we will set `contents: read`. This ensures the workflow has only the permissions it needs to function correctly.

The `permissions` block will be added at the root level of the workflow, applying to all jobs within the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
